### PR TITLE
Adding check for nil before check for empty in `changelog`

### DIFF
--- a/lib/capistrano/slacky/facade/changelog.rb
+++ b/lib/capistrano/slacky/facade/changelog.rb
@@ -19,7 +19,7 @@ module Capistrano
         end
 
         def call
-          if difference.empty?
+          if difference.nil? || difference.empty?
             return ::Capistrano::Slacky::Block::Context.new(
               ::I18n.t("slacky.nothing_has_changed_since_the_previous_release", scope: "capistrano")
             )


### PR DESCRIPTION
Received an error trying to deploy for the first time after adding `slacky`:
`/Users/ameesh/.rvm/gems/ruby-2.6.3/gems/capistrano-slacky-0.1.4/lib/capistrano/slacky/facade/changelog.rb:22:in `call': undefined method `empty?' for nil:NilClass (NoMethodError)`

Fixes #15