### PR TITLE
Add a reverse order for `Diff` to display the correct sequence of merge commits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add a reverse order for `Diff` to display the correct sequence of merge commits. ([@chubchenko][])
 
 ## [0.2.0] - 2021-12-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ bundle install
 Out of the box, the gem has a default configuration:
 
 ```ruby
-set :slacky, username: "ChatOps", # Set your bot's user name.
-             icon_emoji: ":robot_face:", # Emoji to use as the icon for this message.
-             channel: "#deployment", # The name of the channel to send a message to.
-             klass: Capistrano::Slacky::Messaging::Default # The class that responsible for creating a message.
+set :slacky,
+  username: "ChatOps", # Set your bot's user name.
+  icon_emoji: ":robot_face:", # Emoji to use as the icon for this message.
+  channel: "#deployment", # The name of the channel to send a message to.
+  klass: Capistrano::Slacky::Messaging::Default # The class that responsible for creating a message.
 ```
 
 So you can easily tweak your deployment messages and all other configuration to what you want.

--- a/lib/capistrano/slacky/facade/changelog.rb
+++ b/lib/capistrano/slacky/facade/changelog.rb
@@ -25,7 +25,7 @@ module Capistrano
             )
           end
 
-          difference.map do |message|
+          difference.reverse.map do |message|
             ::Capistrano::Slacky::Block::Context.new(
               *message.to_a
             )

--- a/lib/capistrano/slacky/facade/revision.rb
+++ b/lib/capistrano/slacky/facade/revision.rb
@@ -8,10 +8,13 @@ module Capistrano
           @env = env
 
           super(
-            I18n.t("slacky.revision", scope: "capistrano",
-                                      repository_url: ::Capistrano::Slacky.repo.url,
-                                      current: current,
-                                      previous: previous)
+            I18n.t(
+              "slacky.revision",
+              scope: "capistrano",
+              repository_url: ::Capistrano::Slacky.repo.url,
+              current: current,
+              previous: previous
+            )
           )
         end
 

--- a/spec/capistrano/slacky/messaging/default_spec.rb
+++ b/spec/capistrano/slacky/messaging/default_spec.rb
@@ -55,17 +55,17 @@ RSpec.describe Capistrano::Slacky::Messaging::Default do
             {
               type: :context,
               elements: [
-                {type: :mrkdwn, text: ":one:"},
-                {type: :mrkdwn, text: "<https://github.com/chubchenko/capistrano-slacky/commit/02c4c96|02c4c96>"},
-                {type: :mrkdwn, text: "Update changelog & dependency version"}
+                {type: :mrkdwn, text: ":two:"},
+                {type: :mrkdwn, text: "<https://github.com/chubchenko/capistrano-slacky/commit/705253c|705253c>"},
+                {type: :mrkdwn, text: "Build initial version of the gem (#1)"}
               ]
             },
             {
               type: :context,
               elements: [
-                {type: :mrkdwn, text: ":two:"},
-                {type: :mrkdwn, text: "<https://github.com/chubchenko/capistrano-slacky/commit/705253c|705253c>"},
-                {type: :mrkdwn, text: "Build initial version of the gem (#1)"}
+                {type: :mrkdwn, text: ":one:"},
+                {type: :mrkdwn, text: "<https://github.com/chubchenko/capistrano-slacky/commit/02c4c96|02c4c96>"},
+                {type: :mrkdwn, text: "Update changelog & dependency version"}
               ]
             },
             {


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

<!--
  Otherwise, describe the changes:
-->

### What is the purpose of this pull request?

Add a reverse order for `diff` to display the correct sequence of merge commits.

### What changes did you make?

### Is there anything you'd like reviewers to focus on?
